### PR TITLE
fix argument passing to the hub extension script to include all args …

### DIFF
--- a/src/hub/cmd/extensions.go
+++ b/src/hub/cmd/extensions.go
@@ -94,7 +94,6 @@ func arbitraryExtension(args []string) error {
 	if len(what) == 0 {
 		return errors.New("Extensions command has at least one mandatory argument - the name of extension command to call")
 	}
-	fmt.Printf("finalArgs - %v\n", finalArgs)
 
 	return extension(what, finalArgs)
 }


### PR DESCRIPTION
…except the very first agilestacks/automation-hub#786

Note that this changes the previous logic to better match the documentation, which is to take only the first non-flag word as the `what`, and all following arguments are passed to the extension script. 