### PR TITLE
Fix Hub CLI installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ Or directly with `go`:
 
 Install [Hub CLI](https://docs.agilestacks.com/article/zrban5vpb5-install-toolbox#hub_cli):
 
-    curl -O https://github.com/agilestacks/hub/releases/download/v1.0.0/hub.linux_amd64
-    mv hub.linux_amd64 hub
-    chmod +x hub
-    sudo mv hub /usr/local/bin
+    curl -L https://github.com/agilestacks/hub/releases/download/v1.0.0/hub.linux_amd64 -o /usr/local/bin/hub
+    chmod +x /usr/local/bin/hub
 
 There are [Linux amd64](https://github.com/agilestacks/hub/releases/download/v1.0.0/hub.linux_amd64), [Linux arm64](https://github.com/agilestacks/hub/releases/download/v1.0.0/hub.linux_arm64), and [macOS amd64](https://github.com/agilestacks/hub/releases/download/v1.0.0/hub.darwin_amd64) binaries.
 


### PR DESCRIPTION
Previous curl command was downloading html file instead of binary:

![image](https://user-images.githubusercontent.com/44271663/123959177-29937a80-d9ae-11eb-961c-c45da03fbee8.png)
