### PR TITLE
Decouple api commands from build #18

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,6 @@ builds:
       - -X 'github.com/agilestacks/hub/cmd/hub/util.ref={{ .Tag }}'
       - -X 'github.com/agilestacks/hub/cmd/hub/util.commit={{ .ShortCommit }}'
       - -X 'github.com/agilestacks/hub/cmd/hub/util.buildAt={{ time "2006.01.02 15:04:05 MST" }}'
-      - -X 'github.com/agilestacks/hub/cmd/hub/metrics.MetricsServiceKey={{ if index .Env "METRICS_API_SECRET" }}{{ .Env.METRICS_API_SECRET }}{{ else }}{{ end }}'
       - -X 'github.com/agilestacks/hub/cmd/hub/metrics.DDKey={{ if index .Env "DD_CLIENT_API_KEY" }}{{ .Env.DD_CLIENT_API_KEY }}{{ else }}{{ end }}'
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,22 @@ build:
 		-X 'github.com/agilestacks/hub/cmd/hub/util.ref=$(REF)' \
 		-X 'github.com/agilestacks/hub/cmd/hub/util.commit=$(COMMIT)' \
 		-X 'github.com/agilestacks/hub/cmd/hub/util.buildAt=$(BUILD_AT)' \
-		-X 'github.com/agilestacks/hub/cmd/hub/metrics.MetricsServiceKey=$(METRICS_API_SECRET)' \
 		-X 'github.com/agilestacks/hub/cmd/hub/metrics.DDKey=$(DD_CLIENT_API_KEY)'" \
 		github.com/agilestacks/hub/cmd/hub
 .PHONY: build
+
+build-with-api:
+	go build \
+		-o bin/$(OS)/hub \
+		-tags="api" \
+		-ldflags="-s -w \
+		-X 'github.com/agilestacks/hub/cmd/hub/util.ref=$(REF)' \
+		-X 'github.com/agilestacks/hub/cmd/hub/util.commit=$(COMMIT)' \
+		-X 'github.com/agilestacks/hub/cmd/hub/util.buildAt=$(BUILD_AT)' \
+		-X 'github.com/agilestacks/hub/cmd/hub/metrics.MetricsServiceKey=$(METRICS_API_SECRET)' \
+		-X 'github.com/agilestacks/hub/cmd/hub/metrics.DDKey=$(DD_CLIENT_API_KEY)'" \
+		github.com/agilestacks/hub/cmd/hub
+.PHONY: build-with-api
 
 fmt:
 	go fmt github.com/agilestacks/hub/...

--- a/cmd/hub/api/application.go
+++ b/cmd/hub/api/application.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/backup.go
+++ b/cmd/hub/api/backup.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/cloudaccount.go
+++ b/cmd/hub/api/cloudaccount.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/cluster.go
+++ b/cmd/hub/api/cluster.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/component.go
+++ b/cmd/hub/api/component.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/environment.go
+++ b/cmd/hub/api/environment.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/filecache.go
+++ b/cmd/hub/api/filecache.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/http.go
+++ b/cmd/hub/api/http.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/instance.go
+++ b/cmd/hub/api/instance.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/license.go
+++ b/cmd/hub/api/license.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/login.go
+++ b/cmd/hub/api/login.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/logs.go
+++ b/cmd/hub/api/logs.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/parameter.go
+++ b/cmd/hub/api/parameter.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/secret.go
+++ b/cmd/hub/api/secret.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/stack.go
+++ b/cmd/hub/api/stack.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/sync.go
+++ b/cmd/hub/api/sync.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/task.go
+++ b/cmd/hub/api/task.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/template.go
+++ b/cmd/hub/api/template.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/types.go
+++ b/cmd/hub/api/types.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import "time"

--- a/cmd/hub/api/user.go
+++ b/cmd/hub/api/user.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/api/workerpool.go
+++ b/cmd/hub/api/workerpool.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package api
 
 import (

--- a/cmd/hub/cmd/apiBackup.go
+++ b/cmd/hub/cmd/apiBackup.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 EPAM Systems, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build api
+
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agilestacks/hub/cmd/hub/api"
+)
+
+var apiBackupCmd = &cobra.Command{
+	Use:   "backup <get | delete> ...",
+	Short: "List and manage Stack Instance backups",
+}
+
+var apiBackupGetCmd = &cobra.Command{
+	Use:   "get [id | name]",
+	Short: "Show a list of Backups or details about the Backup",
+	Long: `Show a list of all user accessible Backups or details about
+the particular Backup (specify Id or search by name)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return apiBackup(args)
+	},
+}
+
+var apiBackupDeleteCmd = &cobra.Command{
+	Use:   "delete <id | name>",
+	Short: "Delete Backup by Id or name",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return deleteApiBackup(args)
+	},
+}
+
+func apiBackup(args []string) error {
+	if len(args) > 1 {
+		return errors.New("Backup command has one optional argument - id or name of the backup")
+	}
+
+	selector := ""
+	if len(args) > 0 {
+		selector = args[0]
+	}
+	api.Backups(selector, showLogs, jsonFormat)
+
+	return nil
+}
+
+func deleteApiBackup(args []string) error {
+	if len(args) != 1 {
+		return errors.New("Delete Backup command has one mandatory argument - id or name of the backup")
+	}
+
+	api.DeleteBackup(args[0])
+
+	return nil
+}
+
+func init() {
+	apiBackupGetCmd.Flags().BoolVarP(&showLogs, "logs", "l", false,
+		"Show logs")
+	apiBackupGetCmd.Flags().BoolVarP(&jsonFormat, "json", "j", false,
+		"JSON output")
+	apiBackupCmd.AddCommand(apiBackupGetCmd)
+	apiBackupCmd.AddCommand(apiBackupDeleteCmd)
+	apiCmd.AddCommand(apiBackupCmd)
+}

--- a/cmd/hub/cmd/application.go
+++ b/cmd/hub/cmd/application.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/backup.go
+++ b/cmd/hub/cmd/backup.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/agilestacks/hub/cmd/hub/api"
 	"github.com/agilestacks/hub/cmd/hub/compose"
 	"github.com/agilestacks/hub/cmd/hub/lifecycle"
 	"github.com/agilestacks/hub/cmd/hub/util"
@@ -114,53 +113,6 @@ func backupUnbundle(args []string) error {
 	return nil
 }
 
-var apiBackupCmd = &cobra.Command{
-	Use:   "backup <get | delete> ...",
-	Short: "List and manage Stack Instance backups",
-}
-
-var apiBackupGetCmd = &cobra.Command{
-	Use:   "get [id | name]",
-	Short: "Show a list of Backups or details about the Backup",
-	Long: `Show a list of all user accessible Backups or details about
-the particular Backup (specify Id or search by name)`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return apiBackup(args)
-	},
-}
-
-var apiBackupDeleteCmd = &cobra.Command{
-	Use:   "delete <id | name>",
-	Short: "Delete Backup by Id or name",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteApiBackup(args)
-	},
-}
-
-func apiBackup(args []string) error {
-	if len(args) > 1 {
-		return errors.New("Backup command has one optional argument - id or name of the backup")
-	}
-
-	selector := ""
-	if len(args) > 0 {
-		selector = args[0]
-	}
-	api.Backups(selector, showLogs, jsonFormat)
-
-	return nil
-}
-
-func deleteApiBackup(args []string) error {
-	if len(args) != 1 {
-		return errors.New("Delete Backup command has one mandatory argument - id or name of the backup")
-	}
-
-	api.DeleteBackup(args[0])
-
-	return nil
-}
-
 func init() {
 	backupCreateCmd.Flags().StringVarP(&stateManifestExplicit, "state", "s", "",
 		"Path to state file(s), for example hub.yaml.state,s3://bucket/hub.yaml.state")
@@ -186,12 +138,4 @@ func init() {
 	backupCmd.AddCommand(backupCreateCmd)
 	backupCmd.AddCommand(backupUnbundleCmd)
 	RootCmd.AddCommand(backupCmd)
-
-	apiBackupGetCmd.Flags().BoolVarP(&showLogs, "logs", "l", false,
-		"Show logs")
-	apiBackupGetCmd.Flags().BoolVarP(&jsonFormat, "json", "j", false,
-		"JSON output")
-	apiBackupCmd.AddCommand(apiBackupGetCmd)
-	apiBackupCmd.AddCommand(apiBackupDeleteCmd)
-	apiCmd.AddCommand(apiBackupCmd)
 }

--- a/cmd/hub/cmd/cloudaccount.go
+++ b/cmd/hub/cmd/cloudaccount.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/cluster.go
+++ b/cmd/hub/cmd/cluster.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/component.go
+++ b/cmd/hub/cmd/component.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/environment.go
+++ b/cmd/hub/cmd/environment.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/instance.go
+++ b/cmd/hub/cmd/instance.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/login.go
+++ b/cmd/hub/cmd/login.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (
@@ -60,5 +62,5 @@ func login(args []string) error {
 func init() {
 	loginCmd.Flags().StringVarP(&loginUsername, "username", "u", "", "SuperHub username")
 	loginCmd.Flags().StringVarP(&loginPassword, "password", "p", "", "SuperHub password")
-	RootCmd.AddCommand(loginCmd)
+	apiCmd.AddCommand(loginCmd)
 }

--- a/cmd/hub/cmd/logs.go
+++ b/cmd/hub/cmd/logs.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/secret.go
+++ b/cmd/hub/cmd/secret.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/stack.go
+++ b/cmd/hub/cmd/stack.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/task.go
+++ b/cmd/hub/cmd/task.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/template.go
+++ b/cmd/hub/cmd/template.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build api
+
 package cmd
 
 import (

--- a/cmd/hub/cmd/vars.go
+++ b/cmd/hub/cmd/vars.go
@@ -12,21 +12,13 @@ const (
 	envVarNameState             = "HUB_STATE"
 	envVarNameAwsRegion         = "HUB_AWS_REGION"
 	envVarNameComponentsBaseDir = "HUB_COMPONENTS_BASEDIR"
-	envVarNameHubApi            = "HUB_API"
-	envVarNameDerefSecrets      = "HUB_API_DEREF_SECRETS"
-	SuperHubIo                  = ".superhub.io"
-
-	mdpre = "```"
 )
 
 var (
-	supportedClouds            = []string{"aws", "azure", "gcp"}
-	supportedCloudAccountKinds = []string{"aws", "azure", "gcp"}
+	supportedClouds = []string{"aws", "azure", "gcp"}
 )
 
 var (
-	environmentSelector   string
-	templateSelector      string
 	componentName         string
 	componentsBaseDir     string
 	elaborateManifest     string
@@ -36,11 +28,4 @@ var (
 	dryRun                bool
 	osEnvironmentMode     string
 	outputFiles           string
-	waitAndTailDeployLogs bool
-	showSecrets           bool
-	showLogs              bool
-	jsonFormat            bool
-	patchReplace          bool
-	patchRaw              bool
-	createRaw             bool
 )

--- a/cmd/hub/cmd/vars_api.go
+++ b/cmd/hub/cmd/vars_api.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 EPAM Systems, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build api
+
+package cmd
+
+const (
+	SuperHubIo = ".superhub.io"
+
+	envVarNameHubApi       = "HUB_API"
+	envVarNameDerefSecrets = "HUB_API_DEREF_SECRETS"
+
+	mdpre = "```"
+)
+
+var (
+	supportedCloudAccountKinds = []string{"aws", "azure", "gcp"}
+)
+
+var (
+	environmentSelector   string
+	templateSelector      string
+	waitAndTailDeployLogs bool
+	showSecrets           bool
+	showLogs              bool
+	jsonFormat            bool
+	patchReplace          bool
+	patchRaw              bool
+	createRaw             bool
+)

--- a/cmd/hub/config/vars.go
+++ b/cmd/hub/config/vars.go
@@ -17,11 +17,6 @@ var (
 	ConfigFile string
 	CacheFile  string
 
-	ApiBaseUrl      string
-	ApiLoginToken   string
-	ApiDerefSecrets bool
-	ApiTimeout      int = 30
-
 	AwsProfile                  string
 	AwsRegion                   string
 	AwsPreferProfileCredentials bool

--- a/cmd/hub/config/vars_api.go
+++ b/cmd/hub/config/vars_api.go
@@ -4,14 +4,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build !api
+//go:build api
 
-package lifecycle
+package config
 
-import (
-	"github.com/agilestacks/hub/cmd/hub/state"
+var (
+	ApiBaseUrl      string
+	ApiLoginToken   string
+	ApiDerefSecrets bool
+	ApiTimeout      int = 30
 )
-
-func hubSyncer(request *Request) func(*state.StateManifest) {
-	return nil
-}

--- a/cmd/hub/lifecycle/ask.go
+++ b/cmd/hub/lifecycle/ask.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/mattn/go-isatty"
 
-	"github.com/agilestacks/hub/cmd/hub/api"
 	"github.com/agilestacks/hub/cmd/hub/config"
 	"github.com/agilestacks/hub/cmd/hub/manifest"
 	"github.com/agilestacks/hub/cmd/hub/util"
@@ -67,7 +66,7 @@ func AskParameter(parameter manifest.Parameter,
 	}
 
 	if hubEnvironment != "" || hubStackInstance != "" || hubApplication != "" {
-		found, v, errs := api.GetParameterOrMaybeCreateSecret(hubEnvironment, hubStackInstance, hubApplication,
+		found, v, errs := getParameterOrMaybeCreateSecret(hubEnvironment, hubStackInstance, hubApplication,
 			parameter.Name, parameter.Component, isDeploy && parameter.Empty != "allow")
 		if len(errs) > 0 {
 			where := make([]string, 0, 3)

--- a/cmd/hub/lifecycle/ask_param.go
+++ b/cmd/hub/lifecycle/ask_param.go
@@ -8,10 +8,7 @@
 
 package lifecycle
 
-import (
-	"github.com/agilestacks/hub/cmd/hub/state"
-)
-
-func hubSyncer(request *Request) func(*state.StateManifest) {
-	return nil
+func getParameterOrMaybeCreateSecret(environment, stackInstance, application,
+	name, component string, create bool) (bool, string, []error) {
+	return false, "", nil
 }

--- a/cmd/hub/lifecycle/ask_param_api.go
+++ b/cmd/hub/lifecycle/ask_param_api.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 EPAM Systems, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build api
+
+package lifecycle
+
+import "github.com/agilestacks/hub/cmd/hub/api"
+
+func getParameterOrMaybeCreateSecret(environment, stackInstance, application,
+	name, component string, create bool) (bool, string, []error) {
+	return api.GetParameterOrMaybeCreateSecret(environment, stackInstance, application, name, component, create)
+}

--- a/cmd/hub/lifecycle/print.go
+++ b/cmd/hub/lifecycle/print.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/agilestacks/hub/cmd/hub/api"
 	"github.com/agilestacks/hub/cmd/hub/config"
 	"github.com/agilestacks/hub/cmd/hub/manifest"
 	"github.com/agilestacks/hub/cmd/hub/parameters"
@@ -166,27 +165,5 @@ func printStackOutputs(outputs []parameters.ExpandedOutput) {
 				log.Printf("\t%s%s => %s", output.Name, brief, value)
 			}
 		}
-	}
-}
-
-func printStackInstancePatch(patch api.StackInstancePatch) {
-	if len(patch.Outputs) > 0 {
-		log.Print("Outputs to API:")
-		for _, output := range patch.Outputs {
-			brief := ""
-			if output.Brief != "" {
-				brief = fmt.Sprintf("[%s] ", output.Brief)
-			}
-			component := ""
-			if output.Component != "" {
-				component = fmt.Sprintf("%s:", output.Component)
-			}
-			// this is under Trace, no secret value masking required
-			log.Printf("\t%s%s%s => `%v`", brief, component, output.Name, output.Value)
-		}
-	}
-	if len(patch.Provides) > 0 {
-		log.Print("Provides to API:")
-		util.PrintMap2(patch.Provides)
 	}
 }

--- a/cmd/hub/lifecycle/superhub_api.go
+++ b/cmd/hub/lifecycle/superhub_api.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 EPAM Systems, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build api
+
+package lifecycle
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/agilestacks/hub/cmd/hub/api"
+	"github.com/agilestacks/hub/cmd/hub/config"
+	"github.com/agilestacks/hub/cmd/hub/state"
+	"github.com/agilestacks/hub/cmd/hub/storage"
+	"github.com/agilestacks/hub/cmd/hub/util"
+)
+
+func hubSyncer(request *Request) func(*state.StateManifest) {
+	return func(stateManifest *state.StateManifest) {
+		patch := api.TransformStateToApi(stateManifest)
+		remoteStatePaths := storage.RemoteStoragePaths(request.StateFilenames)
+		if len(remoteStatePaths) > 0 {
+			patch.StateFiles = remoteStatePaths
+		}
+		if request.SyncSkipParametersAndOplog {
+			patch.ComponentsEnabled = nil
+			patch.Parameters = nil
+			patch.InflightOperations = nil
+		}
+		if config.Verbose {
+			log.Print("Syncing Stack Instance state to SuperHub")
+			if config.Trace {
+				printStackInstancePatch(patch)
+			}
+		}
+		_, err := api.PatchStackInstance(request.StackInstance, patch, true)
+		if err != nil {
+			util.Warn("Unable to sync stack instance state to SuperHub: %v\n\ttry running sync manually: hub api instance sync %s -s %s ",
+				err, request.StackInstance, strings.Join(request.StateFilenames, ","))
+		}
+	}
+}
+
+func printStackInstancePatch(patch api.StackInstancePatch) {
+	if len(patch.Outputs) > 0 {
+		log.Print("Outputs to API:")
+		for _, output := range patch.Outputs {
+			brief := ""
+			if output.Brief != "" {
+				brief = fmt.Sprintf("[%s] ", output.Brief)
+			}
+			component := ""
+			if output.Component != "" {
+				component = fmt.Sprintf("%s:", output.Component)
+			}
+			// this is under Trace, no secret value masking required
+			log.Printf("\t%s%s%s => `%v`", brief, component, output.Name, output.Value)
+		}
+	}
+	if len(patch.Provides) > 0 {
+		log.Print("Provides to API:")
+		util.PrintMap2(patch.Provides)
+	}
+}

--- a/cmd/hub/metrics/metricsservice.go
+++ b/cmd/hub/metrics/metricsservice.go
@@ -4,91 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//go:build !api
+
 package metrics
 
-import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"log"
-	"net/http"
-	"strings"
-	"time"
-
-	"github.com/agilestacks/hub/cmd/hub/config"
-)
-
-const metricsSeriesResource = "metrics/api/v1/series"
-
 func putMetricsServiceMetric(cmd, host string, additionaTags []string) error {
-	tags := map[string]string{
-		"command": cmd,
-	}
-	if host != "" {
-		tags["machine-id"] = host
-	}
-	if len(additionaTags) > 0 {
-		for _, t := range additionaTags {
-			kv := strings.SplitN(t, ":", 2)
-			k := kv[0]
-			v := "true"
-			if len(kv) > 1 {
-				v = kv[1]
-			}
-			tags[k] = v
-		}
-	}
-	series := Series{
-		Metric{
-			Metric:    "hubcli.commands.usage",
-			Kind:      "count",
-			Tags:      tags,
-			Value:     1,
-			Timestamp: time.Now().Unix(),
-		},
-	}
-	reqBody, err := json.Marshal(series)
-	if err != nil {
-		return err
-	}
-	method := "POST"
-	addr := fmt.Sprintf("%s/%s", config.ApiBaseUrl, metricsSeriesResource)
-	req, err := http.NewRequest(method, addr, bytes.NewReader(reqBody))
-	if err != nil {
-		return err
-	}
-	if config.Trace {
-		log.Printf(">>> %s %s", req.Method, req.URL.String())
-		log.Printf("%s", string(reqBody))
-	}
-	req.Header.Add("Content-type", "application/json")
-	req.Header.Add("X-API-Secret", MetricsServiceKey)
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("Error during HTTP request: %v", err)
-	}
-	if config.Trace {
-		log.Printf("<<< %s %s: %s", req.Method, req.URL.String(), resp.Status)
-	}
-	if resp.StatusCode != 202 {
-		return fmt.Errorf("Metrics Service returned HTTP status %d; expected 202", resp.StatusCode)
-	}
-	var body bytes.Buffer
-	read, _ := body.ReadFrom(resp.Body)
-	resp.Body.Close()
-	bResp := body.Bytes()
-	if read == 0 {
-		return errors.New("Empty response")
-	}
-	var jsResp SeriesResponse
-	err = json.Unmarshal(bResp, &jsResp)
-	if err != nil {
-		return fmt.Errorf("Error unmarshalling HTTP response: %v", err)
-	}
-	if jsResp.Status != "ok" {
-		return fmt.Errorf("Metrics Service returned status `%s`; expected `ok`", jsResp.Status)
-	}
 	return nil
 }

--- a/cmd/hub/metrics/metricsservice_api.go
+++ b/cmd/hub/metrics/metricsservice_api.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 EPAM Systems, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build api
+
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/agilestacks/hub/cmd/hub/config"
+)
+
+const metricsSeriesResource = "metrics/api/v1/series"
+
+func putMetricsServiceMetric(cmd, host string, additionaTags []string) error {
+	tags := map[string]string{
+		"command": cmd,
+	}
+	if host != "" {
+		tags["machine-id"] = host
+	}
+	if len(additionaTags) > 0 {
+		for _, t := range additionaTags {
+			kv := strings.SplitN(t, ":", 2)
+			k := kv[0]
+			v := "true"
+			if len(kv) > 1 {
+				v = kv[1]
+			}
+			tags[k] = v
+		}
+	}
+	series := Series{
+		Metric{
+			Metric:    "hubcli.commands.usage",
+			Kind:      "count",
+			Tags:      tags,
+			Value:     1,
+			Timestamp: time.Now().Unix(),
+		},
+	}
+	reqBody, err := json.Marshal(series)
+	if err != nil {
+		return err
+	}
+	method := "POST"
+	addr := fmt.Sprintf("%s/%s", config.ApiBaseUrl, metricsSeriesResource)
+	req, err := http.NewRequest(method, addr, bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	if config.Trace {
+		log.Printf(">>> %s %s", req.Method, req.URL.String())
+		log.Printf("%s", string(reqBody))
+	}
+	req.Header.Add("Content-type", "application/json")
+	req.Header.Add("X-API-Secret", MetricsServiceKey)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error during HTTP request: %v", err)
+	}
+	if config.Trace {
+		log.Printf("<<< %s %s: %s", req.Method, req.URL.String(), resp.Status)
+	}
+	if resp.StatusCode != 202 {
+		return fmt.Errorf("Metrics Service returned HTTP status %d; expected 202", resp.StatusCode)
+	}
+	var body bytes.Buffer
+	read, _ := body.ReadFrom(resp.Body)
+	resp.Body.Close()
+	bResp := body.Bytes()
+	if read == 0 {
+		return errors.New("Empty response")
+	}
+	var jsResp SeriesResponse
+	err = json.Unmarshal(bResp, &jsResp)
+	if err != nil {
+		return fmt.Errorf("Error unmarshalling HTTP response: %v", err)
+	}
+	if jsResp.Status != "ok" {
+		return fmt.Errorf("Metrics Service returned status `%s`; expected `ok`", jsResp.Status)
+	}
+	return nil
+}


### PR DESCRIPTION
* `//go:build api` directive to ignore `api` related code from the main build
* Usage of stubs in cases where `api` code is used