### PR TITLE
Correct typos in comments and variable names

### DIFF
--- a/cmd/hub/cmd/cluster.go
+++ b/cmd/hub/cmd/cluster.go
@@ -95,7 +95,7 @@ Currently supported cluster types are:
 
 Cluster TLS auth is read from stdin in the order:
 - k8s-aws, hybrid, metal - Client cert, Client key, CA cert (optional).
-- eks - CA cert, optional if --eks-endpoint is omited, then it will be discovered via AWS API
+- eks - CA cert, optional if --eks-endpoint is omitted, then it will be discovered via AWS API
 - openshift - optional CA cert
 GKE and AKS certificates are discovered by import adapter component.
 

--- a/cmd/hub/compose/elaborate.go
+++ b/cmd/hub/compose/elaborate.go
@@ -1118,7 +1118,7 @@ func mergeRequiresTuning(parent, child manifest.RequiresTuning) manifest.Require
 	eraseRequirement := make([]string, 0)
 	eraseComponent := make([]string, 0)
 
-	// go back to front skipping entries that are overriden by newer entries
+	// go back to front skipping entries that are overridden by newer entries
 	for _, req := range newestFirst {
 		skip := false
 		i := strings.Index(req, ":")

--- a/cmd/hub/crypto/crypto.go
+++ b/cmd/hub/crypto/crypto.go
@@ -50,7 +50,7 @@ const (
 
 	helpPassword      = "HUB_CRYPTO_PASSWORD='random password'"
 	helpAwsKms        = "HUB_CRYPTO_AWS_KMS_KEY_ARN='arn:aws:kms:...'"
-	helpAzukeKeyvault = "HUB_CRYPTO_AZURE_KEYVAULT_KEY_ID='https://*.vault.azure.net/keys/...'"
+	helpAzureKeyvault = "HUB_CRYPTO_AZURE_KEYVAULT_KEY_ID='https://*.vault.azure.net/keys/...'"
 	helpGcpKms        = "HUB_CRYPTO_GCP_KMS_KEY_NAME='projects/*/locations/*/keyRings/my-key-ring/cryptoKeys/my-key'"
 )
 
@@ -69,7 +69,7 @@ func IsEncryptedData(data []byte) bool {
 // for password based key the blob is salt
 // for AWS KMS, Azure Key Vault, GCP KMS the blob is encrypted data key
 // if no blob is supplied then a new key is requested
-// if ver is supplied then it must match envionment setup
+// if ver is supplied then it must match environment setup
 func encryptionKeyInit(ver byte, blob []byte) (byte, []byte, []byte, error) {
 	if ver == encryptionV1MarkerByte1 && config.CryptoPassword == "" {
 		return 0, nil, nil,
@@ -81,7 +81,7 @@ func encryptionKeyInit(ver byte, blob []byte) (byte, []byte, []byte, error) {
 	}
 	if ver == encryptionV3MarkerByte1 && config.CryptoAzureKeyVaultKeyId == "" {
 		return 0, nil, nil,
-			fmt.Errorf("Set %s", helpAzukeKeyvault)
+			fmt.Errorf("Set %s", helpAzureKeyvault)
 	}
 	if ver == encryptionV4MarkerByte1 && config.CryptoGcpKmsKeyName == "" {
 		return 0, nil, nil,
@@ -121,7 +121,7 @@ func encryptionKeyInit(ver byte, blob []byte) (byte, []byte, []byte, error) {
 		return encryptionV4MarkerByte1, encryptedKey, clearKey, nil
 	}
 	return 0, nil, nil,
-		fmt.Errorf("Set %s or %s or %s", helpPassword, helpAwsKms, helpAzukeKeyvault)
+		fmt.Errorf("Set %s or %s or %s", helpPassword, helpAwsKms, helpAzureKeyvault)
 }
 
 func maybeEncryptionKeyInit() (byte, []byte, []byte, error) {

--- a/cmd/hub/lifecycle/probe.go
+++ b/cmd/hub/lifecycle/probe.go
@@ -118,7 +118,7 @@ func probeImplementation(dir string, verb string, component *manifest.Manifest) 
 	return false, errors.New(allErrs)
 }
 
-// TODO folowing probes relies on impl file presence
+// TODO following probes relies on impl file presence
 // that may not be the case if the impl is templated
 
 func probeMakefile(dir string, verb string) (bool, error) {

--- a/cmd/hub/metrics/dd.go
+++ b/cmd/hub/metrics/dd.go
@@ -33,14 +33,14 @@ func init() {
 	}
 }
 
-func putDDMetric(cmd, host string, additionaTags []string) error {
-	tags := make([]string, 0, 2+len(additionaTags))
+func putDDMetric(cmd, host string, additionalTags []string) error {
+	tags := make([]string, 0, 2+len(additionalTags))
 	tags = append(tags, "command:"+cmd)
 	if host != "" {
 		tags = append(tags, "machine-id:"+host)
 	}
-	if len(additionaTags) > 0 {
-		tags = append(tags, additionaTags...)
+	if len(additionalTags) > 0 {
+		tags = append(tags, additionalTags...)
 	}
 	series := DDSeries{
 		[]DDMetric{{

--- a/cmd/hub/metrics/metricsservice.go
+++ b/cmd/hub/metrics/metricsservice.go
@@ -8,6 +8,6 @@
 
 package metrics
 
-func putMetricsServiceMetric(cmd, host string, additionaTags []string) error {
+func putMetricsServiceMetric(cmd, host string, additionalTags []string) error {
 	return nil
 }

--- a/cmd/hub/metrics/metricsservice_api.go
+++ b/cmd/hub/metrics/metricsservice_api.go
@@ -23,15 +23,15 @@ import (
 
 const metricsSeriesResource = "metrics/api/v1/series"
 
-func putMetricsServiceMetric(cmd, host string, additionaTags []string) error {
+func putMetricsServiceMetric(cmd, host string, additionalTags []string) error {
 	tags := map[string]string{
 		"command": cmd,
 	}
 	if host != "" {
 		tags["machine-id"] = host
 	}
-	if len(additionaTags) > 0 {
-		for _, t := range additionaTags {
+	if len(additionalTags) > 0 {
+		for _, t := range additionalTags {
 			kv := strings.SplitN(t, ":", 2)
 			k := kv[0]
 			v := "true"

--- a/cmd/hub/parameters/eval.go
+++ b/cmd/hub/parameters/eval.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ${var.name} or
-// #{cel - expression {optionaly one nested level of braces for maps}}
+// #{cel - expression {optionally one nested level of braces for maps}}
 var CurlyReplacement = regexp.MustCompile(`\$\{[^}]+\}|#\{(?:[^}{]|\{[^}{]+\})*\}`)
 
 func StripCurly(match string) (string, bool) {

--- a/cmd/hub/state/explain.go
+++ b/cmd/hub/state/explain.go
@@ -126,7 +126,7 @@ func Explain(elaborateManifests, stateFilenames []string, opLog, global bool, co
 			for _, component := range components {
 				if step, exist := state.Components[component]; exist {
 					fmt.Printf("Component: %s\n", headColor(component))
-					printComponenentState(component, step, prevOutputs, rawOutputs)
+					printComponentState(component, step, prevOutputs, rawOutputs)
 					prevOutputs = step.CapturedOutputs
 				}
 			}
@@ -209,7 +209,7 @@ var headColor = func(str string) string {
 	return str
 }
 
-func printComponenentState(componentName string, step *StateStep, prevOutputs []parameters.CapturedOutput, rawOutputs bool) {
+func printComponentState(componentName string, step *StateStep, prevOutputs []parameters.CapturedOutput, rawOutputs bool) {
 	fmt.Printf("-- Timestamp: %v\n", step.Timestamp.Truncate(time.Second))
 	if t := step.Timestamps; !t.End.IsZero() && !t.Start.IsZero() {
 		fmt.Printf("-- Duration: %v\n", t.End.Sub(t.Start).Round(time.Second).String())

--- a/cmd/hub/util/gzip_test.go
+++ b/cmd/hub/util/gzip_test.go
@@ -7,7 +7,7 @@ import (
 
 const EMPTY_GZIP="\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x01\x00\x00\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00"
 const TEST_STRING="Test string"
-const GZIPED_TEST_STRING="\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\nI-.Q(.)\xca\xccK\a\x04\x00\x00\xff\xff\x92\x9aە\v\x00\x00\x00"
+const GZIPPED_TEST_STRING="\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\nI-.Q(.)\xca\xccK\a\x04\x00\x00\xff\xff\x92\x9aە\v\x00\x00\x00"
 
 func TestGzip(t *testing.T) {
 	type args struct {
@@ -21,7 +21,7 @@ func TestGzip(t *testing.T) {
 	}{
 		{"Should return empty gzip bytes", args{nil}, []byte(EMPTY_GZIP), false},
 		{"Should return empty gzip bytes", args{[]byte{}}, []byte(EMPTY_GZIP), false},
-		{"Should return gziped bytes", args{[]byte(TEST_STRING)}, []byte(GZIPED_TEST_STRING), false},
+		{"Should return gzipped bytes", args{[]byte(TEST_STRING)}, []byte(GZIPPED_TEST_STRING), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestIsGzipData(t *testing.T) {
 		{"Should return false for nil", args{nil}, false},
 		{"Should return false for empty byte array", args{[]byte{}}, false},
 		{"Should return true for empty gzip", args{[]byte(EMPTY_GZIP)}, true},
-		{"Should return true for gzip string", args{[]byte(GZIPED_TEST_STRING)}, true},
+		{"Should return true for gzip string", args{[]byte(GZIPPED_TEST_STRING)}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestGunzip(t *testing.T) {
 	}{
 		{"Should return empty byte array", args{[]byte(EMPTY_GZIP)}, []byte(""), false},
 		{"Should return error", args{nil}, nil, true},
-		{"Should return test string byte array", args{[]byte(GZIPED_TEST_STRING)}, []byte(TEST_STRING), false},
+		{"Should return test string byte array", args{[]byte(GZIPPED_TEST_STRING)}, []byte(TEST_STRING), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,5 @@
 I'm sorry, but there are no canonical unit tests for Hub CTL.
-We test it via end-to-end test suites, that are proprietory.
+We test it via end-to-end test suites, that are proprietary.
 
 I'd [start](https://github.com/epam/hubctl/issues/7) with integration tests to cover:
 - elaborate - assemble manifest from components and compare with reference file;


### PR DESCRIPTION
This PR fixes typos in comments and unexported variables.