### PR TITLE
Allow to select a release channel when hubctl extensions install

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -44,7 +44,7 @@ jobs:
 
       -
         name: Run tests
-        run: go test -race -timeout 30s ./cmd/hub/...
+        run: make test
 
       -
         name: Build

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-# Copyright (c) 2022 EPAM Systems, Inc.
+# Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 .DEFAULT_GOAL := build
 
@@ -22,6 +22,10 @@ bin/$(OS)/staticcheck:
 cel:
 	go install github.com/epam/hubctl/cmd/cel@latest
 .PHONY: cel
+
+deps:
+	go mod download
+.PHONY: deps
 
 build:
 	go build \
@@ -59,7 +63,7 @@ staticcheck: bin/$(OS)/staticcheck
 .PHONY: staticcheck
 
 test:
-	go test -timeout 30s github.com/epam/hubctl/cmd/hub/...
+	go test -race -timeout 60s ./cmd/hub/...
 .PHONY: test
 
 clean:

--- a/cmd/hub/cmd/extensions.go
+++ b/cmd/hub/cmd/extensions.go
@@ -21,6 +21,9 @@ import (
 
 var (
 	knownExtensions = []string{"toolbox", "pull", "ls", "show", "configure", "stack"}
+
+	repo    string
+	channel string
 )
 
 var extensionCmd = cobra.Command{
@@ -53,8 +56,7 @@ var extensionsCmd = &cobra.Command{
 var extensionsInstallCmd = &cobra.Command{
 	Use:   "install [dir]",
 	Short: "Install Hub CTL extensions",
-	Long: `Install Hub CTL extension into ~/.hub/ by cloning git@github.com:epam/hub-extensions.git
-and installing dependencies.`,
+	Long:  fmt.Sprintf("Install Hub CTL extension into ~/.hub/ by cloning %s branch from %s by default and installing dependencies.", ext.ExtensionsRef, ext.ExtensionsGitRemote),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return extensionsInstall(args)
 	},
@@ -63,8 +65,7 @@ and installing dependencies.`,
 var extensionsUpdateCmd = &cobra.Command{
 	Use:   "update [dir]",
 	Short: "Update Hub CTL extensions",
-	Long: `Update Hub CTL extension via hub pull in ~/.hub/
-and refreshing dependencies.`,
+	Long:  "Update Hub CTL extension via git pull in ~/.hub/ by default and refreshing dependencies.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return extensionsUpdate(args)
 	},
@@ -118,8 +119,8 @@ func extensionsInstall(args []string) error {
 		dir = args[0]
 	}
 	config.AggWarnings = false
-	ext.Install(dir)
-	return nil
+
+	return ext.Install(repo, channel, dir)
 }
 
 func extensionsUpdate(args []string) error {
@@ -131,8 +132,8 @@ func extensionsUpdate(args []string) error {
 		dir = args[0]
 	}
 	config.AggWarnings = false
-	ext.Update(dir)
-	return nil
+
+	return ext.Update(dir)
 }
 
 func init() {
@@ -143,6 +144,12 @@ func init() {
 		RootCmd.AddCommand(&cmd)
 	}
 	RootCmd.AddCommand(arbitraryExtensionCmd)
+
+	extensionsInstallCmd.Flags().StringVarP(&repo, "repo", "", ext.ExtensionsGitRemote,
+		"Git repository remote URL with extensions")
+	extensionsInstallCmd.Flags().StringVarP(&channel, "channel", "", ext.ExtensionsRef,
+		"Git branch or tag name in remote git repository")
+
 	extensionsCmd.AddCommand(extensionsInstallCmd)
 	extensionsCmd.AddCommand(extensionsUpdateCmd)
 	RootCmd.AddCommand(extensionsCmd)

--- a/cmd/hub/cmd/root.go
+++ b/cmd/hub/cmd/root.go
@@ -31,6 +31,7 @@ var RootCmd = &cobra.Command{
 	Long: `Hub CTL is a stack composition and lifecycle tool:
 - template and stack creation, stack deploy / undeploy / backup lifecycle;
 - stack and component parameters, output variables, and status`,
+	SilenceUsage: true,
 
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		config.Update()
@@ -47,7 +48,6 @@ var RootCmd = &cobra.Command{
 func Execute() {
 	ctx := context.WithValue(context.Background(), contextKey, &CmdContext{})
 	if err := RootCmd.ExecuteContext(ctx); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/hub/ext/install.go
+++ b/cmd/hub/ext/install.go
@@ -7,6 +7,7 @@
 package ext
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -18,15 +19,15 @@ import (
 )
 
 const (
-	extensionsGitRemote = "https://github.com/epam/hub-extensions.git"
-	extensionsRef       = "master"
+	ExtensionsGitRemote = "https://github.com/epam/hub-extensions.git"
+	ExtensionsRef       = "master"
 )
 
 func defaultExtensionsDir() string {
 	return filepath.Join(os.Getenv("HOME"), hubDir)
 }
 
-func Install(dir string) {
+func Install(repo, ref, dir string) error {
 	if dir == "" {
 		dir = defaultExtensionsDir()
 	}
@@ -34,17 +35,17 @@ func Install(dir string) {
 	_, err := os.Stat(filepath.Join(dir, ".git"))
 	if err == nil {
 		util.Warn("`%s` already exist; try `hubctl extensions update`?", dir)
-		return
+		return nil
 	}
 
 	if config.Debug {
-		log.Printf("Cloning extensions repository: %s", extensionsGitRemote)
+		log.Printf("Cloning extensions repository: %s", repo)
 	}
 
-	err = git.Clone(extensionsGitRemote, extensionsRef, dir)
+	err = git.Clone(repo, ref, dir)
 
 	if err != nil {
-		log.Fatalf("unable to install extensions to `%s` directory: %v", dir, err)
+		return fmt.Errorf("unable to install extensions to `%s` directory: %v", dir, err)
 	}
 
 	postInstall(dir)
@@ -52,16 +53,18 @@ func Install(dir string) {
 	if config.Verbose {
 		log.Printf("Hub CTL extensions installed into %s", dir)
 	}
+
+	return nil
 }
 
-func Update(dir string) {
+func Update(dir string) error {
 	if dir == "" {
 		dir = defaultExtensionsDir()
 	}
 
-	err := git.Pull(extensionsRef, dir)
+	err := git.Pull("", dir)
 	if err != nil {
-		log.Fatalf("unable to update extensions in `%s` directory: %v", dir, err)
+		return fmt.Errorf("unable to update extensions in `%s` directory: %v", dir, err)
 	}
 
 	postInstall(dir)
@@ -69,6 +72,8 @@ func Update(dir string) {
 	if config.Verbose {
 		log.Printf("Hub CTL extensions updated in %s", dir)
 	}
+
+	return nil
 }
 
 func postInstall(dir string) {

--- a/cmd/hub/ext/install_test.go
+++ b/cmd/hub/ext/install_test.go
@@ -18,7 +18,7 @@ import (
 func TestExtensionsGitRepoUrlIsValid(t *testing.T) {
 	rem := goGit.NewRemote(memory.NewStorage(), &goGitConfig.RemoteConfig{
 		Name: "origin",
-		URLs: []string{extensionsGitRemote},
+		URLs: []string{ExtensionsGitRemote},
 	})
 
 	_, err := rem.List(&goGit.ListOptions{})
@@ -26,16 +26,26 @@ func TestExtensionsGitRepoUrlIsValid(t *testing.T) {
 	assert.NoError(t, err, "When extensions git repository URL is valid, git ls-remote should not return error")
 }
 
-func TestExtensionsInstallAndUpdate(t *testing.T) {
+func TestExtensionsInstallAndUpdateBranchChannel(t *testing.T) {
 	dir := t.TempDir()
 
 	t.Log("Install extensions")
-	assert.NotPanics(t, func() {
-		Install(dir)
-	}, "When install extensions it should not panic")
+	err := Install(ExtensionsGitRemote, ExtensionsRef, dir)
+	assert.NoError(t, err, "When install extensions it should not panic")
 
 	t.Log("Update extensions")
-	assert.NotPanics(t, func() {
-		Update(dir)
-	}, "When update extensions, it should not panic")
+	err = Update(dir)
+	assert.NoError(t, err, "When update extensions, it should not panic")
+}
+
+func TestExtensionsInstallAndUpdateTagChannel(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Log("Install extensions")
+	err := Install(ExtensionsGitRemote, "stable", dir)
+	assert.NoError(t, err, "When install extensions it should not panic")
+
+	t.Log("Update extensions")
+	err = Update(dir)
+	assert.NoError(t, err, "When update extensions, it should not panic")
 }

--- a/cmd/hub/git/git.go
+++ b/cmd/hub/git/git.go
@@ -17,16 +17,19 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 )
 
-func Clone(remote, ref, dir string) error {
-	referenceName, err := findRemoteBranch(remote, ref)
+func cloneErrMsgFormat(remoteUrl, ref, dir string, err error) error {
+	return fmt.Errorf("unable to clone git repo %s at `%s` into `%s`: %v", remoteUrl, ref, dir, err)
+}
 
+func Clone(remoteUrl, ref, dir string) error {
+	reference, err := findRemoteReference(remoteUrl, ref)
 	if err != nil {
-		return fmt.Errorf("unable to clone git repo %s at `%s` into `%s`: %v", remote, ref, dir, err)
+		return cloneErrMsgFormat(remoteUrl, ref, dir, err)
 	}
 
 	_, err = goGit.PlainClone(dir, false, &goGit.CloneOptions{
-		URL:               remote,
-		ReferenceName:     referenceName,
+		URL:               remoteUrl,
+		ReferenceName:     reference.Name(),
 		SingleBranch:      true,
 		Progress:          log.Default().Writer(),
 		Tags:              goGit.NoTags,
@@ -34,7 +37,7 @@ func Clone(remote, ref, dir string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("unable to clone git repo %s at `%s` into `%s`: %v", remote, ref, dir, err)
+		return cloneErrMsgFormat(remoteUrl, ref, dir, err)
 	}
 
 	return nil
@@ -46,10 +49,41 @@ func pullErrMsgFormat(dir string, err error) error {
 	return fmt.Errorf("unable to pull git repo in `%s` directory: %v", dir, err)
 }
 
-func Pull(ref, dir string) error {
+func Pull(targetRef, dir string) error {
 	repo, err := goGit.PlainOpen(dir)
 	if err != nil {
 		return pullErrMsgFormat(dir, err)
+	}
+
+	reference, err := repo.Head()
+	if err != nil {
+		return pullErrMsgFormat(dir, err)
+	}
+
+	if targetRef == "" {
+		refs, err := repo.References()
+		if err != nil {
+			return pullErrMsgFormat(dir, err)
+		}
+		defer refs.Close()
+
+		for ref, err := refs.Next(); err == nil; {
+			if ref.Hash() == reference.Hash() {
+				reference = ref
+				break
+			}
+		}
+	} else {
+		remote, err := repo.Remote(remoteName)
+		if err != nil {
+			return pullErrMsgFormat(dir, err)
+		}
+
+		remoteUrl := remote.Config().URLs[0]
+		reference, err = findRemoteReference(remoteUrl, targetRef)
+		if err != nil {
+			return pullErrMsgFormat(dir, err)
+		}
 	}
 
 	worktree, err := repo.Worktree()
@@ -57,21 +91,9 @@ func Pull(ref, dir string) error {
 		return pullErrMsgFormat(dir, err)
 	}
 
-	repoConfig, err := repo.Config()
-	if err != nil {
-		return pullErrMsgFormat(dir, err)
-	}
-
-	remote := repoConfig.Remotes[remoteName].URLs[0]
-
-	referenceName, err := findRemoteBranch(remote, ref)
-	if err != nil {
-		return pullErrMsgFormat(dir, err)
-	}
-
 	err = worktree.Pull(&goGit.PullOptions{
 		RemoteName:        remoteName,
-		ReferenceName:     referenceName,
+		ReferenceName:     reference.Name(),
 		SingleBranch:      true,
 		Progress:          log.Default().Writer(),
 		RecurseSubmodules: goGit.NoRecurseSubmodules,
@@ -79,7 +101,8 @@ func Pull(ref, dir string) error {
 
 	if err != nil {
 		if err == goGit.NoErrAlreadyUpToDate {
-			log.Printf("%v", err)
+			log.Print(err)
+			return nil
 		} else {
 			return pullErrMsgFormat(dir, err)
 		}
@@ -101,28 +124,29 @@ var refFindOrder = []string{
 	refTagPrefix + "%s",
 }
 
-func findRemoteBranch(remote, targetRef string) (plumbing.ReferenceName, error) {
-	rem := goGit.NewRemote(memory.NewStorage(), &goGitConfig.RemoteConfig{
+func findRemoteReference(remoteUrl, targetRef string) (*plumbing.Reference, error) {
+	remote := goGit.NewRemote(memory.NewStorage(), &goGitConfig.RemoteConfig{
 		Name: remoteName,
-		URLs: []string{remote},
+		URLs: []string{remoteUrl},
 	})
 
-	refs, err := rem.List(&goGit.ListOptions{})
+	refs, err := remote.List(&goGit.ListOptions{})
 
 	if err != nil {
-		return "", fmt.Errorf("unable to get ref list of `%s` remote: %v", remote, err)
+		return nil, fmt.Errorf("unable to get ref list of `%s` remote: %v", remoteUrl, err)
 	}
 
 	for _, refNameFormat := range refFindOrder {
 		for _, ref := range refs {
 			name := ref.Name().String()
 			if util.ContainsPrefix(refPrefixes, name) {
-				if (util.ContainsPrefix(refPrefixes, targetRef) && targetRef == name) || fmt.Sprintf(refNameFormat, targetRef) == name {
-					return ref.Name(), nil
+				targetName := fmt.Sprintf(refNameFormat, targetRef)
+				if (util.ContainsPrefix(refPrefixes, targetRef) && targetRef == name) || targetName == name {
+					return ref, nil
 				}
 			}
 		}
 	}
 
-	return "", fmt.Errorf("unable to find git ref `%s` in `%s` remote", targetRef, remote)
+	return nil, fmt.Errorf("unable to find git ref `%s` in `%s` remote", targetRef, remoteUrl)
 }

--- a/cmd/hub/git/git_test.go
+++ b/cmd/hub/git/git_test.go
@@ -13,40 +13,57 @@ import (
 )
 
 const remoteUrl = "https://github.com/epam/hubctl.git"
-const ref = "master"
+const branchRef = "master"
+const tagRef = "v1.0.0"
 
 func TestClone(t *testing.T) {
 	dir := t.TempDir()
 
-	err := Clone(remoteUrl, ref, dir)
+	err := Clone(remoteUrl, branchRef, dir)
 	assert.NoError(t, err, "should return nil error if repo and ref exist")
 }
 
-func TestPull(t *testing.T) {
+func TestPullBranch(t *testing.T) {
 	dir := t.TempDir()
 
-	err := Clone(remoteUrl, ref, dir)
+	err := Clone(remoteUrl, branchRef, dir)
 	assert.NoError(t, err, "should return nil error if repo and ref exist")
 
-	err = Pull(ref, dir)
+	err = Pull("", dir)
+	assert.NoError(t, err, "should return nil error if repo and using HEAD ref")
+
+	err = Pull(branchRef, dir)
+	assert.NoError(t, err, "should return nil error if repo and ref exist")
+}
+
+func TestPullTag(t *testing.T) {
+	dir := t.TempDir()
+
+	err := Clone(remoteUrl, tagRef, dir)
+	assert.NoError(t, err, "should return nil error if repo and ref exist")
+
+	err = Pull("", dir)
+	assert.NoError(t, err, "should return nil error if repo exist and using HEAD ref")
+
+	err = Pull(tagRef, dir)
 	assert.NoError(t, err, "should return nil error if repo and ref exist")
 }
 
 func TestFindRemoteBranch(t *testing.T) {
-	refName, err := findRemoteBranch(remoteUrl, "develop")
+	ref, err := findRemoteReference(remoteUrl, "develop")
 
-	assert.True(t, refName.IsBranch(), "should return reference as branch")
-	assert.Equal(t, "refs/heads/develop", refName.String(), "ref full name should equals to refs/heads/develop")
+	assert.True(t, ref.Name().IsBranch(), "should return reference as branch")
+	assert.Equal(t, "refs/heads/develop", ref.Name().String(), "ref full name should equals to refs/heads/develop")
 	assert.NoError(t, err, "should return nil error if repo branch/tag is exist")
 
-	refName, err = findRemoteBranch(remoteUrl, "v1.0.0")
+	ref, err = findRemoteReference(remoteUrl, "v1.0.0")
 
-	assert.True(t, refName.IsTag(), "should return reference as tag")
-	assert.Equal(t, "refs/tags/v1.0.0", refName.String(), "ref full name should equals to refs/tags/v1.0.0")
+	assert.True(t, ref.Name().IsTag(), "should return reference as tag")
+	assert.Equal(t, "refs/tags/v1.0.0", ref.Name().String(), "ref full name should equals to refs/tags/v1.0.0")
 	assert.NoError(t, err, "should return nil error if repo branch/tag is exist")
 
-	refName, err = findRemoteBranch(remoteUrl, "i-hope-there-is-no-such-branch-or-tag")
+	ref, err = findRemoteReference(remoteUrl, "i-hope-there-is-no-such-branch-or-tag")
 
-	assert.Empty(t, refName, "ref should be empty")
+	assert.Nil(t, ref, "ref should be nil")
 	assert.Error(t, err, "should return error if repo branch/tag does not exist")
 }


### PR DESCRIPTION
Added to flags `--repo` and `--channel` to `hubctl extensions install` command.
Also disable print of usage in case if hubctl command returns error.